### PR TITLE
Updating documentation, re-adding years, months, days, etc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,28 +58,47 @@ Example
 -------
 
 Enter the time into the textbox in the following format::
+
+    3 days 2:20:10
+
+or::
     
-    6w 3d 18h 30min 23s 10ms 150us
+    3d 2:20:10
 
 This is interpreted as::
     
-    6 weeks 3 days 18 hours 30 minutes 23 seconds 1 milliseconds 150 microseconds
+    3 days 2 hours 20 minutes 10 seconds
 
 In your application it will be represented as a python ``datetime.timedelta``::
     
-    45 days, 18:30:23.010150
+    3 days, 2:20:10
 
-This will be stored into the database as a 'bigint' with the value of::
-    
-    3954623010150
+This will be stored into the database as a 'bigint'.
 
+You can be rather more elaborate by using microseconds and weeks (or even months, and years
+with a configuration setting)::
+
+    1 year, 2 months, 3 weeks, 4 days, 5:06:07.000008
  
 Years and Months
 ----------------
 
-You will need to uncomment two lines in timestring.py to support years and months. This causes a 
-loss of precision because the number of days in a month is not exact. This has not been extensively tested.
+You will need to set a setting in your ``settings.py`` to allow your users to enter
+values for years or months. This causes a loss of precision because the number 
+of days in a month is not exact. This has not been extensively tested.
 
+To allow users to enter ``X years`` or ``X months`` add::
+
+    ``DURATIONFIELD_ALLOW_YEARS = True``
+
+or::
+
+    ``DURATIONFIELD_ALLOW_MONTHS = True``
+
+Currently, those fields will be translated into days using either 365 or 30 respectively.
+
+To override this setting, add an entry into your settings named ``DURATIONFIELD_YEARS_TO_DAYS``
+or ``DURATIONFIELD_MONTHS_TO_DAYS`` setting a new translation value.
 
 Development
 -----------
@@ -132,3 +151,4 @@ Thanks to the contributors to django-durationfield:
  * Guillaume Libersat (https://github.com/glibersat)
  * Jason Mayfield (https://github.com/jwmayfield)
  * silent1mezzo (https://github.com/silent1mezzo)
+ * Adam Coddington (https://github.com/latestrevision)

--- a/durationfield/tests/settings.py
+++ b/durationfield/tests/settings.py
@@ -17,3 +17,6 @@ else:
 INSTALLED_APPS = (
     'durationfield.tests',
 )
+
+DURATIONFIELD_ALLOW_YEARS = True
+DURATIONFIELD_ALLOW_MONTHS = True

--- a/durationfield/tests/tests.py
+++ b/durationfield/tests/tests.py
@@ -26,7 +26,7 @@ class DurationFieldTests(TestCase):
 
     def _delta_to_microseconds(self, td):
         """
-        Get the tota number of microseconds in a timedelta, normalizing days and
+        Get the total number of microseconds in a timedelta, normalizing days and
         seconds to microseconds.
         """
         SECONDS_TO_US = 1000 * 1000
@@ -116,16 +116,64 @@ class DurationFieldTests(TestCase):
             model_test = TestModel.objects.get(pk=model_test.pk)
             self.assertEquals(td, model_test.duration_field)
 
-    #def testForm(self):
-        #model_test = TestModel()
-        #model_test.duration_field = timestring.to_timedelta("3d 8h 56s")
-        #model_test.save()
-        #model_test = TestModel.objects.get(id__exact=1)
+    def testInputTime(self):
+        delta = timestring.str_to_timedelta("10:23")
+        seconds = (10 * 60 * 60) + (23 * 60)
+        self.assertEquals(seconds, delta.seconds)
 
-        ##form = DurationField()
-        ##self.assertContains("input", str)
+    def testInputTimeSeonds(self):
+        delta = timestring.str_to_timedelta("12:21:24")
+        seconds = (12 * 60 * 60) + (21 * 60) + 24
+        self.assertEquals(seconds, delta.seconds)
 
+    def testInputTimeSecondsMicroseconds(self):
+        delta = timestring.str_to_timedelta("11:20:22.000098")
+        seconds = (11 * 60 * 60) + (20 * 60) + 22
+        self.assertEquals(seconds, delta.seconds)
+        self.assertEquals(98, delta.microseconds)
 
+    def testInputAll(self):
+        delta = timestring.str_to_timedelta("1 year, 10 months, 3 weeks, 2 days, 3:40:50")
+        days = (
+                    (1 * 365) +
+                    (10 * 30) +
+                    (3 * 7) +
+                    2
+                )
+        seconds = (
+                    (3 * 60 * 60) +
+                    (40 * 60) + 
+                    50
+                )
+        self.assertEquals(
+                    days, delta.days
+                )
+        self.assertEquals(
+                    seconds, delta.seconds
+                )
 
+    def testInputAllAbbreviated(self):
+        delta = timestring.str_to_timedelta("2y 9m 1w 20d 0:10:39")
+        days = (
+                    (2 * 365) +
+                    (9 * 30) +
+                    (1 * 7) +
+                    20
+                )
+        seconds = (
+                    (0 * 60 * 60) +
+                    (10 * 60) + 
+                    39
+                )
+        self.assertEquals(
+                    days, delta.days
+                )
+        self.assertEquals(
+                    seconds, delta.seconds
+                )
 
-
+    def testInputDaysOnly(self):
+        delta = timestring.str_to_timedelta("24 days")
+        self.assertEquals(
+                    24, delta.days
+                )

--- a/durationfield/utils/timestring.py
+++ b/durationfield/utils/timestring.py
@@ -27,7 +27,7 @@ def str_to_timedelta(td_str):
     if not td_str:
         return None
 
-    time_format = r"(?:(?P<days>\d+)\W*(?:days?|d),?)?\W*(?:(?P<hours>\d+):(?P<minutes>\d+)(?::(?P<seconds>\d+)(?:\.(?P<microseconds>\d+))?)?)?"
+    time_format = r"(?:(?P<weeks>\d+)\W*(?:weeks?|w),?)?\W*(?:(?P<days>\d+)\W*(?:days?|d),?)?\W*(?:(?P<hours>\d+):(?P<minutes>\d+)(?::(?P<seconds>\d+)(?:\.(?P<microseconds>\d+))?)?)?"
     if ALLOW_MONTHS:
         time_format = r"(?:(?P<months>\d+)\W*(?:months?|m),?)?\W*" + time_format
     if ALLOW_YEARS:
@@ -46,6 +46,7 @@ def str_to_timedelta(td_str):
         time_groups["days"] = time_groups["days"] + (time_groups["years"] * YEARS_TO_DAYS)
     if "months" in time_groups.keys():
         time_groups["days"] = time_groups["days"] + (time_groups["months"] * MONTHS_TO_DAYS)
+    time_groups["days"] = time_groups["days"] + (time_groups["weeks"] * 7)
 
     return timedelta(
         days=time_groups["days"],


### PR DESCRIPTION
- Updating documentation to reflect earlier changes in 14121e6.
- Changing string parser to use regular expression.
- Allow user to set variable in settings to allow use of years or months.
- Re-adding years and months to durationfield string parsing.
- Adding tests to timestring parsing.
