### PR TITLE
TBD: Return an existing Django type from get_internal_type

### DIFF
--- a/durationfield/db/models/fields/duration.py
+++ b/durationfield/db/models/fields/duration.py
@@ -32,13 +32,21 @@ class DurationField(six.with_metaclass(models.SubfieldBase, Field)):
         #self.max_digits, self.decimal_places = 20, 6
 
     def get_internal_type(self):
-        return "DurationField"
+        """
+        This gets mapped to the corresponding database type, via
+        `Field.db_parameters` (for migrations in Django 1.7).
+        See https://code.djangoproject.com/ticket/2226.
+        """
+        return "BigIntegerField"
 
     def db_type(self, connection=None):
         """
         Returns the database column data type for this field, for the provided connection.
         Django 1.1.X does not support multiple db's and therefore does not pass in the db
-        connection string. Called by Django only when the framework constructs the table
+        connection string. Called by Django only when the framework constructs the table.
+        With migrations (Django 1.7), this is not called, but `get_internal_type` via
+        `Field.db_parameters`. Keeping this for backwards compatibility.
+        (Also, probably South uses this!)
         """
         return "bigint"
 


### PR DESCRIPTION
Please consider this pull request for discussion only.

btw: the tests passed before and after, although they should have failed before (for Django 1.7). I've thought that just a call to `save()` should have triggered an error.
Maybe it's related to sqlite being used, or because of TestModels being involved?!
(I could not get my hands on the durationfieldtest.db, even after commenting out "Destroying test database for alias ..." part from Django.

From the commit:
This is used in Django 1.7 migrations to derive the correct database
type from.

I cannot see, why "DurationField" should be returned here (added in
892b6e9).

This leaves `db_type` as-is, since it's used with older Django versions
and South probably.

Fixes https://github.com/johnpaulett/django-durationfield/issues/15.
Related Django ticket: https://code.djangoproject.com/ticket/22260
