### PR TITLE
Add an option to treat XX:XX as MM:SS instead of HH:MM.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,6 +110,15 @@ Currently, those fields will be translated into days using either 365 or 30 resp
 To override this setting, add an entry into your settings named ``DURATIONFIELD_YEARS_TO_DAYS``
 or ``DURATIONFIELD_MONTHS_TO_DAYS`` setting a new translation value.
 
+Short Duration Use Cases
+------------------------
+
+The default functionality is to assume that ``12:34`` means 12 hours and 34 minutes but if your users are usually entering durations less than an hour you can change this so ``12:34`` means 12 minutes and 34 seconds instead.
+
+To change this, add an entry to your settings like this::
+
+    ``DURATIONFIELD_ASSUME_MMSS = True``
+
 Development
 -----------
 

--- a/durationfield/utils/timestring.py
+++ b/durationfield/utils/timestring.py
@@ -13,6 +13,7 @@ ALLOW_MONTHS = getattr(settings, "DURATIONFIELD_ALLOW_MONTHS", False)
 ALLOW_YEARS = getattr(settings, "DURATIONFIELD_ALLOW_YEARS", False)
 MONTHS_TO_DAYS = getattr(settings, "DURATIONFIELD_MONTHS_TO_DAYS", 30)
 YEARS_TO_DAYS = getattr(settings, "DURATIONFIELD_YEARS_TO_DAYS", 365)
+ASSUME_MMSS = getattr(settings, "DURATIONFIELD_ASSUME_MMSS", False)
 
 
 def str_to_timedelta(td_str):
@@ -28,8 +29,11 @@ def str_to_timedelta(td_str):
     """
     if not td_str:
         return None
+    if not ASSUME_MMSS:
+        time_format = r"(?:(?P<weeks>\d+)\W*(?:weeks?|w),?)?\W*(?:(?P<days>\d+)\W*(?:days?|d),?)?\W*(?:(?P<hours>\d+):(?P<minutes>\d+)(?::(?P<seconds>\d+)(?:\.(?P<microseconds>\d+))?)?)?"
+    else:
+        time_format = r"(?:(?P<weeks>\d+)\W*(?:weeks?|w),?)?\W*(?:(?P<days>\d+)\W*(?:days?|d),?)?\W*(?:(?P<hours>\d+):)??(?:(?P<minutes>\d+)(?::(?P<seconds>\d+))?)(?:\.(?P<microseconds>\d+))?$"
 
-    time_format = r"(?:(?P<weeks>\d+)\W*(?:weeks?|w),?)?\W*(?:(?P<days>\d+)\W*(?:days?|d),?)?\W*(?:(?P<hours>\d+):(?P<minutes>\d+)(?::(?P<seconds>\d+)(?:\.(?P<microseconds>\d+))?)?)?"
     if ALLOW_MONTHS:
         time_format = r"(?:(?P<months>\d+)\W*(?:months?|m),?)?\W*" + time_format
     if ALLOW_YEARS:


### PR DESCRIPTION
Hello, I'm using this in radio station logging software to keep track of the length of songs.  I didn't want users to have to enter 0:2:00 for a 2 minute song so I created this option.  Thanks for the original!
