### PR TITLE
Feature seconds/days precision support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,16 +27,15 @@ and report back any issues.
 Django Versions
 ---------------
 
-django-durationfield supports Django 1.4.2 through Django 1.5+, with the goal to
-target the currently support versions of Django releases in the future. So as
-the Django Project drops support for older versions, django-durationfield will
-do the same.
+django-durationfield supports Django 1.4.2 through Django 1.8. As the Django
+Project drops support for older versions, django-durationfield will do the same.
 
 Django 1.4.2 is a minimum version as it introduced `compatibility features
 <https://docs.djangoproject.com/en/1.5/topics/python3/>`_ for
 supporting both Python 2 and Python 3.
 
-django-durationfield has support for Python 3.3.
+django-durationfield has support for Python versions 2.6, 2.7, 3.3, 3.4 and pypy
+however note that Python 2.6 support was `dropped in Django 1.7 <https://docs.djangoproject.com/en/1.8/faq/install/#what-python-version-can-i-use-with-django>`_.
 
 Please report any bugs or patches in improve version support.
 
@@ -109,6 +108,65 @@ Currently, those fields will be translated into days using either 365 or 30 resp
 
 To override this setting, add an entry into your settings named ``DURATIONFIELD_YEARS_TO_DAYS``
 or ``DURATIONFIELD_MONTHS_TO_DAYS`` setting a new translation value.
+
+Storing Seconds or Days
+-----------------------
+
+By default the data is stored in the database as microseconds, however if
+required you can store either seconds or days. Obviously doing this causes you
+to lose precision.
+
+This feature is useful if you are dealing with a legacy system that can't be
+changed that stores data in seconds or you simply don't need the precision of
+microseconds.
+
+Seconds Usage
+~~~~~~~~~~~~~
+
+The following causes the value in the database to be interpreted as seconds.
+
+In models.py::
+
+    from durationfield.db.models.fields.duration import DurationField
+
+    class Time(models.Model):
+        ...
+        duration = DurationField(precision='seconds')
+        ...
+
+    t = Time(duration='0:01:15.00123')
+    print str(t.duration) # -> '0:01:15'
+
+In the database the duration field would be set to :code:`75` (ie.. :code:`60+15`).
+
+Note that when setting duration as an integer it's interpreted as seconds, ie::
+
+    t = Time(duration=75)
+    print str(t.duration) # -> '0:01:15'
+
+Days Usage
+~~~~~~~~~~
+
+The following causes the value in the database to be interpreted as days.
+
+In models.py::
+
+    from durationfield.db.models.fields.duration import DurationField
+
+    class Time(models.Model):
+        ...
+        duration = DurationField(precision='days')
+        ...
+
+    t = Time(duration='15d 0:01:15.00123')
+    print str(t.duration) # -> '15 days, 0:00:00'
+
+In the database the duration field would be set to :code:`15`.
+
+Note that when setting duration as an integer it's interpreted as days, ie::
+
+    t = Time(duration=15)
+    print str(t.duration) # -> '15 days, 0:00:00'
 
 Development
 -----------

--- a/durationfield/utils/timestring.py
+++ b/durationfield/utils/timestring.py
@@ -15,7 +15,7 @@ MONTHS_TO_DAYS = getattr(settings, "DURATIONFIELD_MONTHS_TO_DAYS", 30)
 YEARS_TO_DAYS = getattr(settings, "DURATIONFIELD_YEARS_TO_DAYS", 365)
 
 
-def str_to_timedelta(td_str):
+def str_to_timedelta(td_str, precision='microseconds'):
     """
     Returns a timedelta parsed from the native string output of a timedelta.
 
@@ -67,10 +67,24 @@ def str_to_timedelta(td_str):
         time_groups["days"] = time_groups["days"] + (time_groups["months"] * MONTHS_TO_DAYS)
     time_groups["days"] = time_groups["days"] + (time_groups["weeks"] * 7)
 
-    return timedelta(
-        days=time_groups["days"],
-        hours=time_groups["hours"],
-        minutes=time_groups["minutes"],
-        seconds=time_groups["seconds"],
-        microseconds=time_groups["microseconds"]
-    )
+    if precision == 'microseconds':
+        kwargs = dict(
+            days=time_groups["days"],
+            hours=time_groups["hours"],
+            minutes=time_groups["minutes"],
+            seconds=time_groups["seconds"],
+            microseconds=time_groups["microseconds"]
+        )
+    elif precision == 'seconds':
+        kwargs = dict(
+            days=time_groups["days"],
+            hours=time_groups["hours"],
+            minutes=time_groups["minutes"],
+            seconds=time_groups["seconds"]
+        )
+    elif precision == 'days':
+        kwargs = dict(days=time_groups["days"])
+    else:
+        raise NotImplementedError("Precision '%s' is not implemented." % precision)
+
+    return timedelta(**kwargs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+description-file = README.rst
+
+[wheel]
+universal = 1

--- a/tests/models.py
+++ b/tests/models.py
@@ -15,3 +15,11 @@ class TestNullableModel(models.Model):
 
 class TestDefaultModel(models.Model):
     duration_field = DurationField(default=DEFAULT_DURATION)
+
+
+class TestSecondPrecisionModel(models.Model):
+    duration_field = DurationField(precision='seconds')
+
+
+class TestDayPrecisionModel(models.Model):
+    duration_field = DurationField(precision='days')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,3 +22,5 @@ DURATIONFIELD_ALLOW_YEARS = True
 DURATIONFIELD_ALLOW_MONTHS = True
 
 SECRET_KEY = '_2roqfdp42u3qn23xc=z4**vueob2#!yloe=_+go&wxsi&glt1'
+
+MIDDLEWARE_CLASSES = {}

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,22 @@
 [tox]
-envlist = 
-    py33-1.6, py27-1.6, py33-1.5, py27-1.5, py27-1.4, docs
+envlist =
+    py{26}-django{14,15,16},
+    py{27,py}-django{14,15,16,17,18},
+    py{33,34}-django{17,18},
+    docs
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/tests
+sitepackages = False
+setenv = PYTHONPATH = {toxinidir}:{toxinidir}/tests
+         PIP_DOWNLOAD_CACHE={homedir}/.pip-cache
 commands =
     {envbindir}/django-admin.py test --settings=tests.settings
-basepython = python2.7
-
-[testenv:py27-1.5]
 deps =
-    Django==1.5.5
-
-[testenv:py27-1.4]
-deps =
-    Django==1.4.10
-
-[testenv:py33-1.5]
-basepython = python3.3
-deps =
-    Django==1.5.5
-
-[testenv:py27-1.6]
-basepython = python3.3
-deps =
-    Django==1.6.2
-
-[testenv:py33-1.6]
-basepython = python3.3
-deps =
-    Django==1.6.2
+    django14: Django==1.4.10
+    django15: Django==1.5.5
+    django16: Django==1.6.2
+    django17: Django==1.7.8
+    django18: Django==1.8.2
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
I have to deal with a bunch of legacy databases which have durations stored as both seconds and days - they are appropriate values given the intention thus I don't think it should be expected the underlying data should change (it can't, they are legacy, closed source apps that can't be changed).

Thus, I've added support for days and seconds.

In the process I've also updated the tox.ini to support various other configurations (ie.. python 2.6, 3.3, 3.4 and pypy) and all tests are passing for all environments.